### PR TITLE
Forward arguments from batch scripts to bash scripts

### DIFF
--- a/setup/autobuild/rrg/pm3-flash-all.bat
+++ b/setup/autobuild/rrg/pm3-flash-all.bat
@@ -3,5 +3,5 @@ cd "%~dp0client"
 call setup.bat
 ::If you want to force the COM port add it to the line, example:
 ::bash pm3-flash-all COM3
-bash pm3-flash-all
+bash pm3-flash-all %*
 pause

--- a/setup/autobuild/rrg/pm3-flash-bootrom.bat
+++ b/setup/autobuild/rrg/pm3-flash-bootrom.bat
@@ -3,5 +3,5 @@ cd "%~dp0client"
 call setup.bat
 ::If you want to force the COM port add it to the line, example:
 ::bash pm3-flash-bootrom COM3
-bash pm3-flash-bootrom
+bash pm3-flash-bootrom %*
 pause

--- a/setup/autobuild/rrg/pm3-flash-fullimage.bat
+++ b/setup/autobuild/rrg/pm3-flash-fullimage.bat
@@ -3,5 +3,5 @@ cd "%~dp0client"
 call setup.bat
 ::If you want to force the COM port add it to the line, example:
 ::bash pm3-flash-fullimage COM3
-bash pm3-flash-fullimage
+bash pm3-flash-fullimage %*
 pause

--- a/setup/autobuild/rrg/pm3.bat
+++ b/setup/autobuild/rrg/pm3.bat
@@ -3,5 +3,5 @@ cd "%~dp0client"
 call setup.bat
 ::If you want to force the COM port use the -p parameter, example:
 ::bash pm3 -p COM3
-bash pm3
+bash pm3 %*
 pause


### PR DESCRIPTION
Hi. Thank you for this great tool.
For users who use terminal(cmd, powershell) on Windows, I think they might want to pass some arguments to the `pm3` or `pm3-flash-all` script, which is called in corresponding `xxx.bat`. Adding a simple `%*` in the batch script forwards the arguments passed to the `xxx.bat`, and users can still open the pm3 by double clicking the batch file. I think there is no regression.