### PR TITLE
Reduce unnecessary packages

### DIFF
--- a/setup/packages.txt
+++ b/setup/packages.txt
@@ -21,7 +21,7 @@ mingw-w64-x86_64-python
 mingw-w64-x86_64-python-pip
 mingw-w64-x86_64-python-setuptools
 mingw-w64-x86_64-jansson
-mingw-w64-x86_64-qt5
+mingw-w64-x86_64-qt5-base
 mingw-w64-x86_64-gdb
 mingw-w64-x86_64-openocd
 mingw-w64-x86_64-opencl-icd-git


### PR DESCRIPTION
Most of the packages in `mingw-w64-x86_64-qt5` are unnecessary.  The simple GUI in the Proxmark3 only requires qt5-base.
Plus, some unused packages in `mingw-w64-x86_64-qt5` cost a lot of time to install.