### PR TITLE
Upgrading from Qt5 to Qt6

### DIFF
--- a/setup/packages.txt
+++ b/setup/packages.txt
@@ -23,7 +23,7 @@ mingw-w64-x86_64-python
 mingw-w64-x86_64-python-pip
 mingw-w64-x86_64-python-setuptools
 mingw-w64-x86_64-jansson
-mingw-w64-x86_64-qt5-base
+mingw-w64-x86_64-qt6-base
 mingw-w64-x86_64-gdb
 mingw-w64-x86_64-openocd
 mingw-w64-x86_64-opencl-icd


### PR DESCRIPTION
Hi!

I've migrated the proxmark3 codebase to support Qt6 by default. 
So far it is is working on all tested Linux distros, OSX with brew & WSL.
NVX tested manually on Proxspace:
```
did a clean, removed qt5 with pacman -Rnc mingw-w64-x86_64-qt5-base and installed qt6 with pacman -Syu mingw-w64-x86_64-qt6-base (seems like proxspace only installs qt5-base, but my mingw did have a bunch of other qt5 related packages installed too, figured I'd remove qt5 even though both can be installed side by side since nothing else needs it anyway and more reliable test if qt6 is the only thing installed)

GUI support:       QT6 found, enabled (Qt version 6.10.1 in C:/msys64/mingw64/lib)
built fine
```

So when you've time, a new Proxspace release with Qt6 instead of (or along with) Qt5 would be welcome.
Thanks!