### PR TITLE
fix: Qt6 DLL path, CC/CXX env vars, add PowerShell build wrapper

### DIFF
--- a/Build-Proxmark3.ps1
+++ b/Build-Proxmark3.ps1
@@ -1,0 +1,141 @@
+<#
+.SYNOPSIS
+    Build Proxmark3 firmware and client using ProxSpace MSYS2 environment.
+.DESCRIPTION
+    PowerShell wrapper that sets correct environment variables (TMP, TEMP,
+    CC, CXX, MINGW_HOME) before invoking the MSYS2 make toolchain.
+    Avoids the /tmp -> C:\WINDOWS\ path translation bug that occurs when
+    building from git-bash or other non-MSYS2 shells.
+.PARAMETER ProxSpacePath
+    Path to ProxSpace root. Default: directory containing this script.
+.PARAMETER PM3Path
+    Path to Proxmark3 source. Default: {ProxSpacePath}\pm3
+.PARAMETER Target
+    Make target. Default: 'all' (bootrom + firmware + client).
+    Use 'client' for client-only builds.
+.PARAMETER Jobs
+    Parallel make jobs. Default: CPU core count.
+.PARAMETER Flash
+    After a successful build, flash bootrom then fullimage to the device.
+.PARAMETER Port
+    COM port for flashing. Default: auto-detect (first Proxmark3 VID).
+.EXAMPLE
+    .\Build-Proxmark3.ps1
+    .\Build-Proxmark3.ps1 -Flash -Port COM5
+    .\Build-Proxmark3.ps1 -Target client -Jobs 8
+#>
+[CmdletBinding()]
+param(
+    [string]$ProxSpacePath = $PSScriptRoot,
+    [string]$PM3Path = "",
+    [string]$Target = "all",
+    [int]$Jobs = [Environment]::ProcessorCount,
+    [switch]$Flash,
+    [string]$Port = ""
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not $PM3Path) { $PM3Path = Join-Path $ProxSpacePath "pm3" }
+
+# --- Pre-flight checks ---
+$make = Join-Path $ProxSpacePath "msys2\usr\bin\make.exe"
+$bash = Join-Path $ProxSpacePath "msys2\usr\bin\bash.exe"
+$gcc  = Join-Path $ProxSpacePath "msys2\mingw64\bin\gcc.exe"
+$armgcc = Join-Path $ProxSpacePath "msys2\mingw64\bin\arm-none-eabi-gcc.exe"
+
+foreach ($tool in @($make, $bash, $gcc)) {
+    if (-not (Test-Path $tool)) {
+        throw "Required tool not found: $tool — is ProxSpace installed at $ProxSpacePath?"
+    }
+}
+if (-not (Test-Path $PM3Path)) {
+    throw "Proxmark3 source not found at $PM3Path. Clone it with: git clone https://github.com/RfidResearchGroup/proxmark3.git $PM3Path"
+}
+
+# --- Inject env vars ---
+# These override any inherited Windows env vars that would confuse MSYS2/MinGW
+$msysTmp = Join-Path $ProxSpacePath "msys2\tmp"
+$null = New-Item -ItemType Directory -Force -Path $msysTmp
+
+$env:TEMP       = $msysTmp
+$env:TMP        = $msysTmp
+$env:MINGW_HOME = Join-Path $ProxSpacePath "msys2\mingw64"
+$env:CC         = $gcc
+$env:CXX        = Join-Path $ProxSpacePath "msys2\mingw64\bin\g++.exe"
+$env:MSYSTEM    = "MINGW64"
+$env:PATH       = "{0}\msys2\mingw64\bin;{0}\msys2\usr\bin;{1}" -f $ProxSpacePath, $env:PATH
+
+Write-Host "=== Proxmark3 Build ==="
+Write-Host "  ProxSpace : $ProxSpacePath"
+Write-Host "  PM3 source: $PM3Path"
+Write-Host "  Target    : $Target"
+Write-Host "  Jobs      : $Jobs"
+Write-Host ""
+
+# --- Build ---
+$makeArgs = @("-j$Jobs", "SKIPREVENGTEST=1")
+if ($Target -eq "all") {
+    # Build bootrom, firmware, and client sequentially
+    foreach ($t in @("bootrom/all", "armsrc/all")) {
+        Write-Host "[*] Building $t ..."
+        & $make -C $PM3Path $t @makeArgs
+        if ($LASTEXITCODE -ne 0) { throw "Build failed at target: $t (exit $LASTEXITCODE)" }
+    }
+    Write-Host "[*] Building client ..."
+    & $make -C $PM3Path "client" @makeArgs
+    if ($LASTEXITCODE -ne 0) { throw "Client build failed (exit $LASTEXITCODE)" }
+} else {
+    Write-Host "[*] Building $Target ..."
+    & $make -C $PM3Path $Target @makeArgs
+    if ($LASTEXITCODE -ne 0) { throw "Build failed at target: $Target (exit $LASTEXITCODE)" }
+}
+
+Write-Host ""
+Write-Host "[+] Build succeeded."
+
+# --- Flash (optional) ---
+if ($Flash) {
+    $client = Join-Path $PM3Path "client\proxmark3.exe"
+    if (-not (Test-Path $client)) { throw "proxmark3.exe not found — build may be incomplete." }
+
+    # Auto-detect COM port if not specified
+    if (-not $Port) {
+        $pm3Device = Get-PnpDevice -Class 'Ports' -Status OK -ErrorAction SilentlyContinue |
+            Where-Object { $_.InstanceId -match '9AC4' } |
+            Select-Object -First 1
+        if ($pm3Device -and $pm3Device.FriendlyName -match 'COM(\d+)') {
+            $Port = "COM$($Matches[1])"
+            Write-Host "[*] Auto-detected Proxmark3 on $Port"
+        } else {
+            throw "No Proxmark3 detected. Specify -Port manually."
+        }
+    }
+
+    Write-Host "[*] Flashing bootrom to $Port ..."
+    & $client $Port --flash --unlock-bootloader --image (Join-Path $PM3Path "bootrom\obj\bootrom.elf")
+    if ($LASTEXITCODE -ne 0) { throw "Bootrom flash failed." }
+
+    Write-Host "[*] Waiting 5s for device to re-enumerate ..."
+    Start-Sleep -Seconds 5
+
+    # Re-detect port (may change after bootloader update)
+    $pm3Device = Get-PnpDevice -Class 'Ports' -Status OK -ErrorAction SilentlyContinue |
+        Where-Object { $_.InstanceId -match '9AC4' } |
+        Select-Object -First 1
+    if ($pm3Device -and $pm3Device.FriendlyName -match 'COM(\d+)') {
+        $newPort = "COM$($Matches[1])"
+        if ($newPort -ne $Port) {
+            Write-Host "[!] Port changed from $Port to $newPort after bootloader flash"
+            $Port = $newPort
+        }
+    }
+
+    Write-Host "[*] Flashing fullimage to $Port ..."
+    & $client $Port --flash --image (Join-Path $PM3Path "armsrc\obj\fullimage.elf")
+    if ($LASTEXITCODE -ne 0) { throw "Fullimage flash failed." }
+
+    Write-Host ""
+    Write-Host "[+] Flash complete. Verify with: proxmark3.exe $Port -c 'hw version'"
+}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,37 @@ Please note that more detail is available on the wiki: https://github.com/RfidRe
  2. Flash the bootrom with `./pm3-flash-bootrom`.
  3. Flash the fullimage with `./pm3-flash-fullimage`.
  4. Wait for the process to complete.
- 
- ## Setup video
- [![ProxSpace Windows 10 setup](http://img.youtube.com/vi/-DLYp-yWmtQ/0.jpg)](http://www.youtube.com/watch?v=-DLYp-yWmtQ "ProxSpace Windows 10 setup")
+
+## PowerShell Build Wrapper
+
+For users who prefer PowerShell over the MSYS2 terminal, `Build-Proxmark3.ps1` provides a one-command build experience:
+
+```powershell
+# Build everything (bootrom + firmware + client)
+.\Build-Proxmark3.ps1
+
+# Build and flash
+.\Build-Proxmark3.ps1 -Flash -Port COM5
+
+# Build client only with 8 parallel jobs
+.\Build-Proxmark3.ps1 -Target client -Jobs 8
+```
+
+The wrapper automatically sets the correct `TMP`, `TEMP`, `CC`, `CXX`, and `MINGW_HOME` environment variables, avoiding linker errors that can occur when building outside the MSYS2 shell.
+
+## Known Issues
+
+### crapto1 download timeout (issue #59)
+
+The upstream tarball host `crapto1.netgarage.org` has been unreliable since 2024. If the build hangs fetching `craptev1-v1.1.tar.xz`, manually download it from a mirror:
+
+https://raw.githubusercontent.com/ApertureLabsLtd/craptern/master/craptev1-v1.1.tar.xz
+
+Place it in the expected directory before re-running the build.
+
+### System MinGW interference (issue #60)
+
+If you have a separate MinGW installation (Qt Creator, TDM-GCC, etc.) on your system, it may inject incorrect `CC`/`CXX`/`MINGW_HOME` paths into the build. This is now handled automatically by the ProxSpace setup scripts. If you still encounter issues, ensure the `setup/user_setup.sh` exports are being sourced by checking that `which gcc` inside the ProxSpace shell points to `/mingw64/bin/gcc.exe`.
+
+## Setup video
+[![ProxSpace Windows 10 setup](http://img.youtube.com/vi/-DLYp-yWmtQ/0.jpg)](http://www.youtube.com/watch?v=-DLYp-yWmtQ "ProxSpace Windows 10 setup")

--- a/setup/autobuild.sh
+++ b/setup/autobuild.sh
@@ -41,8 +41,14 @@ function copy_common {
 
 	#Copy required libraries to client/libs
 	ldd "$srcDir/client/proxmark3.exe" | grep "=> /mingw" | awk '{print $3}' | xargs -I '{}' cp -v '{}' "$dstDir/client/libs"
-	#Copy qt5 platform dll
-	cp "$mingwDir/share/qt5/plugins/platforms/qwindows.dll" "$dstDir/client/libs"
+	#Copy qt6 platform dll (updated from qt5 after Qt6 upgrade in PR #62)
+	if [ -f "$mingwDir/share/qt6/plugins/platforms/qwindows.dll" ]; then
+		cp "$mingwDir/share/qt6/plugins/platforms/qwindows.dll" "$dstDir/client/libs"
+	elif [ -f "$mingwDir/share/qt5/plugins/platforms/qwindows.dll" ]; then
+		cp "$mingwDir/share/qt5/plugins/platforms/qwindows.dll" "$dstDir/client/libs"
+	else
+		echo "WARNING: Could not find qwindows.dll in qt5 or qt6 paths"
+	fi
 	#Copy firmware
 	cp "$srcDir/armsrc/obj/fullimage.elf" "$dstDir/client"
 	cp "$srcDir/bootrom/obj/bootrom.elf" "$dstDir/client"
@@ -131,4 +137,3 @@ function loop_folders {
 check_requirements
 cd $pm3Dir
 loop_folders
-

--- a/setup/user_setup.sh
+++ b/setup/user_setup.sh
@@ -18,3 +18,11 @@ GROUP_MISSING=$( grep -Fq "$GROUP_SID" /etc/group )$?
 if [ $GROUP_MISSING != 0 ]; then
   echo $MKGROUP_CURRENT >> /etc/group
 fi
+
+# ProxSpace compiler overrides — use bundled MinGW64, ignore host env.
+# Fixes issue #60: users with a system MinGW install (Qt Creator, TDM-GCC)
+# inherit incorrect compiler paths that break the Proxmark3 build.
+export MINGW_HOME=/mingw64
+export CC=/mingw64/bin/gcc.exe
+export CXX=/mingw64/bin/g++.exe
+export AR=/mingw64/bin/ar.exe


### PR DESCRIPTION
## Summary\n\nFixes three active build issues and adds a PowerShell convenience wrapper.\n\n### Fixes\n\n**`setup/autobuild.sh` — Wrong Qt DLL path after Qt6 upgrade (closes #63)**\nPR #62 upgraded Qt5 → Qt6 but left the DLL copy path referencing `qt5/`. Updated to try `qt6/` first with fallback to `qt5/` for backwards compatibility.\n\n**`setup/user_setup.sh` — Missing CC/CXX/MINGW_HOME (closes #60)**\nUsers with a system MinGW install (Qt Creator, TDM-GCC) inherit incorrect compiler paths. Added explicit exports using MSYS2-relative paths (`/mingw64/bin/gcc.exe`) so ProxSpace's bundled MinGW64 always takes precedence.\n\n**`README.md` — crapto1 download workaround (references #59)**\nDocumented the `crapto1.netgarage.org` timeout issue and provided a mirror URL for manual download.\n\n### New: `Build-Proxmark3.ps1`\n\nPowerShell wrapper script for Windows users who prefer not to use the MSYS2 terminal. Features:\n- Sets correct `TMP`, `TEMP`, `CC`, `CXX`, `MINGW_HOME` env vars automatically\n- Pre-flight checks for required tools\n- Supports `-Target` (all/client/bootrom), `-Jobs`, `-Flash`, `-Port` parameters\n- Auto-detects Proxmark3 COM port via USB VID for flashing\n- Handles COM port re-enumeration after bootloader flash\n\n### Testing\n\nTested on Windows 11 with ProxSpace v3.11, PM3 Generic (AT91SAM7S512), successfully building Iceman master v4.21128 (a72f66b).\n\n### Related Issues\n- Closes #63 (Qt6 DLL path)\n- Closes #60 (CC/CXX/MINGW_HOME env vars)\n- References #59 (crapto1 download timeout)"