### PR TITLE
fix(setup): update Qt platform DLL copy path to Qt6

### DIFF
--- a/setup/autobuild.sh
+++ b/setup/autobuild.sh
@@ -41,8 +41,8 @@ function copy_common {
 
 	#Copy required libraries to client/libs
 	ldd "$srcDir/client/proxmark3.exe" | grep "=> /mingw" | awk '{print $3}' | xargs -I '{}' cp -v '{}' "$dstDir/client/libs"
-	#Copy qt5 platform dll
-	cp "$mingwDir/share/qt5/plugins/platforms/qwindows.dll" "$dstDir/client/libs"
+	#Copy qt6 platform dll
+	cp "$mingwDir/share/qt6/plugins/platforms/qwindows.dll" "$dstDir/client/libs"
 	#Copy firmware
 	cp "$srcDir/armsrc/obj/fullimage.elf" "$dstDir/client"
 	cp "$srcDir/bootrom/obj/bootrom.elf" "$dstDir/client"


### PR DESCRIPTION
**Context**
In a previous commit (8fe27c0d9), the environment packages were upgraded from Qt5 to Qt6 (specifically mingw-w64-x86_64-qt6-base). However, the autobuild script was still pointing to the old Qt5 path to copy the Qt platform DLL (qwindows.dll), which caused build issues or missing DLL warnings.

This PR updates the copy command to point to the correct Qt6 directory structure.

**Changes**
Updated the source path of qwindows.dll in 

autobuild.sh
 from: $mingwDir/share/qt5/plugins/platforms/qwindows.dll to: $mingwDir/share/qt6/plugins/platforms/qwindows.dll

**Verification**
Verified that the directory structure under $mingwDir/share/qt6 contains the appropriate plugins.
Script now targets the Qt6 dependencies defined in setup/packages.txt.